### PR TITLE
Fixed metadata propagation bug

### DIFF
--- a/snakeplane/plugin_factory.py
+++ b/snakeplane/plugin_factory.py
@@ -141,9 +141,6 @@ class PluginFactory:
                 and len(current_plugin._state_vars.required_input_names) == 0
             ):
                 self._init_func(current_plugin)
-                self._build_metadata(current_plugin)
-                for _, anchor in current_plugin._state_vars.output_anchors.items():
-                    anchor.push_metadata(current_plugin)
 
             # Boilerplate Side Effects
             current_plugin.initialized = val
@@ -208,22 +205,25 @@ class PluginFactory:
         None
         This method produces side-effects by registering the user defined function
         """
-
         @_monitor("push_all_records")
         @wraps(func)
         def wrap_push_all_records(current_plugin, n_record_limit: int):
             if len(current_plugin._state_vars.required_input_names) != 0:
                 current_plugin.assert_all_inputs_connected()
 
-            if current_plugin.update_only_mode:
-                return True
+            if (
+                current_plugin.update_only_mode
+                and len(current_plugin._state_vars.required_input_names) == 0
+            ):
+                self._build_metadata(current_plugin)
+                for _, anchor in current_plugin._state_vars.output_anchors.items():
+                    anchor.push_metadata(current_plugin)
 
-            if len(current_plugin._state_vars.required_input_names) == 0:
+            if len(current_plugin._state_vars.required_input_names) == 0 and not current_plugin.update_only_mode:
                 # Only call the users defined function when there are no required
                 # inputs, since this is the only scenario where something interesting
                 # happens in this function
                 func(current_plugin, n_record_limit)
-                return True
 
             return True
 


### PR DESCRIPTION
Fixed a bug for source tools where the metadata propagation doesn't happen at the proper time. This resulted in downstream tools not properly receiving metadata, despite the appearance that metadata was propagated out of the original tool. 