### PR TITLE
Chunking functionality and documentation

### DIFF
--- a/snakeplane/helper_classes.py
+++ b/snakeplane/helper_classes.py
@@ -263,13 +263,6 @@ class AyxPlugin:
         return sdk.RecordInfo(self._engine_vars.alteryx_engine)
 
 
-class ChunkStage(Enum):
-    none = 1
-    first = 2
-    middle = 3
-    last = 4
-
-
 class AyxPluginInterface:
     """Input interface base definition."""
 
@@ -285,20 +278,7 @@ class AyxPluginInterface:
         self._interface_state = SimpleNamespace(
             input_complete=False, d_progress_percentage=0, data_processing_mode="batch"
         )
-        self.chunk_stage = ChunkStage.none
-
-    @property
-    def chunk_stage(self) -> str:
-        """Interface chunk stage getter."""
-        return self.__chunk_stage
-
-    @chunk_stage.setter
-    def chunk_stage(self, new_chunk_stage: object) -> None:
-        """Interface chunk stage setter."""
-        if not type(new_chunk_stage) == ChunkStage:
-            raise ValueError("chunk_stage must be set to an instance of ChunkStage")
-
-        self.__chunk_stage = new_chunk_stage
+        self.is_last_chunk = None
 
     @property
     def metadata(self) -> object:

--- a/snakeplane/helper_classes.py
+++ b/snakeplane/helper_classes.py
@@ -17,7 +17,8 @@
 import copy
 import os
 import sys
-from collections import OrderedDict, namedtuple, UserDict
+from collections import OrderedDict, UserDict, namedtuple
+from enum import Enum
 from functools import partial
 from types import SimpleNamespace
 from typing import Any, List, Tuple, Union
@@ -262,6 +263,9 @@ class AyxPlugin:
         return sdk.RecordInfo(self._engine_vars.alteryx_engine)
 
 
+ChunkStage = Enum("ChunkStage", "none first middle last")
+
+
 class AyxPluginInterface:
     """Input interface base definition."""
 
@@ -277,6 +281,20 @@ class AyxPluginInterface:
         self._interface_state = SimpleNamespace(
             input_complete=False, d_progress_percentage=0, data_processing_mode="batch"
         )
+        self.chunk_stage = ChunkStage["none"]
+
+    @property
+    def chunk_stage(self) -> str:
+        """Interface chunk stage getter."""
+        return self.__chunk_stage
+
+    @chunk_stage.setter
+    def chunk_stage(self, new_chunk_stage: object) -> None:
+        """Interface chunk stage setter."""
+        if not type(new_chunk_stage) == ChunkStage:
+            raise ValueError("chunk_stage must be set to an instance of ChunkStage")
+
+        self.__chunk_stage = new_chunk_stage
 
     @property
     def metadata(self) -> object:

--- a/snakeplane/helper_classes.py
+++ b/snakeplane/helper_classes.py
@@ -263,7 +263,11 @@ class AyxPlugin:
         return sdk.RecordInfo(self._engine_vars.alteryx_engine)
 
 
-ChunkStage = Enum("ChunkStage", "none first middle last")
+class ChunkStage(Enum):
+    none = 1
+    first = 2
+    middle = 3
+    last = 4
 
 
 class AyxPluginInterface:
@@ -281,7 +285,7 @@ class AyxPluginInterface:
         self._interface_state = SimpleNamespace(
             input_complete=False, d_progress_percentage=0, data_processing_mode="batch"
         )
-        self.chunk_stage = ChunkStage["none"]
+        self.chunk_stage = ChunkStage.none
 
     @property
     def chunk_stage(self) -> str:

--- a/snakeplane/plugin_factory.py
+++ b/snakeplane/plugin_factory.py
@@ -707,10 +707,9 @@ class PluginFactory:
                     >= chunk_size
                 ):
 
-                    self._build_metadata(plugin)
-
                     if current_interface.chunk_stage == ChunkStage.none:
                         self._init_func(plugin)
+                        self._build_metadata(plugin)
                         current_interface.chunk_stage = ChunkStage.first
 
                     func(plugin)
@@ -724,10 +723,9 @@ class PluginFactory:
             def chunk_ii_close(current_interface: object):
                 plugin = current_interface.parent
 
-                self._build_metadata(plugin)
-
                 if current_interface.chunk_stage == ChunkStage.none:
                     self._init_func(plugin)
+                    self._build_metadata(plugin)
 
                 if not plugin.update_only_mode:
 

--- a/snakeplane/plugin_factory.py
+++ b/snakeplane/plugin_factory.py
@@ -21,7 +21,7 @@ from functools import wraps
 import AlteryxPythonSDK as sdk
 
 import snakeplane.interface_utilities as interface_utils
-from snakeplane.helper_classes import AyxPlugin, AyxPluginInterface
+from snakeplane.helper_classes import AyxPlugin, AyxPluginInterface, ChunkStage
 
 import xmltodict
 
@@ -530,7 +530,7 @@ class PluginFactory:
         self._build_metadata = decorated_build_metadata
         return
 
-    def process_data(self, mode: str = "batch", input_type: str = "list"):
+    def process_data(self, mode: str = "batch", input_type: str = "list", chunk_size: int = 1000):
         """
         Decorate a function to inject user defined functionality.
 
@@ -545,7 +545,7 @@ class PluginFactory:
         Parameters
         ----------
         mode : str
-        One of two options: 'batch' or 'stream'
+        One of three options: 'batch', 'chunk', or 'stream'
 
         Batch mode will cause the tool to pull in all input records for
         a given input anchor, collect them into a single data
@@ -554,6 +554,17 @@ class PluginFactory:
         object.
         An important note for batch is that the User Defined Function will be
         executed one time, on the entire set of records at once.
+
+        Chunk mode will cause the tool to pull a group (chunk) of records in
+        at a time, and make this chunk of records available to the User
+        Defined Function in the respective input_anchor object.
+        In addition, a chunk stage (ChunkStage) will be added to the
+        interface object which will resolve to one of the chunk stage values
+        defined in AyxPluginInterface. This allows the User Defined Function
+        to behave differently based on the chunking stage.
+        It should be noted that when the chunk_size is greater than the size
+        of the data coming in, chunk mode will only run the final chunk
+        stage.
 
         Stream mode will cause the tool to pull one input record in at a time,
         and make this single record available to the User Defined Function in
@@ -567,6 +578,11 @@ class PluginFactory:
         the UDF by the respective input_anchor contained in the input_mgr
         will either contain records in the form of a Python list or a
         Pandas DataFrame object.
+
+        chunk_size: int
+        Determines the number of records which should make up each chunk. The
+        final chunk will usually be less than the chunk_size, and this case
+        is handled internally by this wrapper.
 
         Returns
         -------
@@ -621,6 +637,21 @@ class PluginFactory:
                 [sdk.FieldType.v_string, sdk.FieldType.int64])
             output_anchor.set_data(output_df)
 
+        @factory.process_data(mode="chunk", input_type="dataframe", chunk_size=50)
+        def process_data(input_mgr, output_mgr, user_data, logger):
+            input_anchor = input_mgr.get_anchor("AnchorNameFromConfigXmlFile")
+            input_df = input_anchor.get_data()
+
+            if(input_anchor[0].chunk_stage == ChunkStage["first"]):
+                message = f"First chunk contains records |{input_df.iloc[0]}| to |{input_df.iloc[49]}|"
+                logger.display_info_msg(message)
+            if(input_anchor[0].chunk_stage == ChunkStage["middle"]):
+                message = f"This middle chunk contains records |{input_df.iloc[0]}| to |{input_df.iloc[49]}|"
+                logger.display_info_msg(message)
+            if(input_anchor[0].chunk_stage == ChunkStage["last"]):
+                message = f"Last chunk contains records |{input_df.iloc[0]}| to |{input_df.iloc[49]}|"
+                logger.display_info_msg(message)
+
         @factory.process_data(mode="stream")
         def process_each_record(input_mgr, output_mgr, user_data, logger):
             input_anchor = input_mgr.get_anchor("AnchorNameFromConfigXmlFile")
@@ -666,6 +697,45 @@ class PluginFactory:
                     func(plugin)
 
             @_run_only_if_pi_initialized
+            def chunk_ii_push_record(
+                plugin: object, current_interface: object, in_record: sdk.RecordRef
+            ):
+                current_interface.accumulate_record(in_record)
+
+                if (
+                    len(current_interface._interface_record_vars.record_list_in)
+                    >= chunk_size
+                ):
+
+                    if current_interface.chunk_stage == ChunkStage["none"]:
+                        self._init_func(plugin)
+                        current_interface.chunk_stage = ChunkStage["first"]
+
+                    self._build_metadata(plugin)
+
+                    func(plugin)
+
+                    # set after func called so first run maintains original chunk_stage
+                    current_interface.chunk_stage = ChunkStage["middle"]
+
+                    plugin.clear_accumulated_records()
+
+            @_run_only_if_pi_initialized
+            def chunk_ii_close(current_interface: object):
+                plugin = current_interface.parent
+
+                if current_interface.chunk_stage == ChunkStage["none"]:
+                    self._init_func(plugin)
+
+                self._build_metadata(plugin)
+
+                current_interface.chunk_stage = ChunkStage["last"]
+
+                func(plugin)
+
+                plugin.clear_accumulated_records()
+
+            @_run_only_if_pi_initialized
             def stream_ii_push_record(
                 plugin: object, current_interface: object, in_record: sdk.RecordRef
             ):
@@ -695,6 +765,9 @@ class PluginFactory:
                     )
                 )
                 self.build_ii_close(batch_ii_close)
+            elif mode.lower() == "chunk":
+                self.build_ii_push_record(chunk_ii_push_record)
+                setattr(self._plugin.plugin_interface, "ii_close", chunk_ii_close)
             elif mode.lower() == "stream":
                 # Streaming is the unique case for initialization
                 # It should be ran in pi_init.
@@ -704,7 +777,7 @@ class PluginFactory:
                 self.build_pi_push_all_records(source_pi_push_all_records)
             else:
                 err_str = """Mode parameter of process_data must be one of
-                    'batch'|'stream'|'source'"""
+                    'batch'|'chunk'|'stream'|'source'"""
                 raise ValueError(err_str)
 
         return decorator_process_data

--- a/snakeplane/plugin_factory.py
+++ b/snakeplane/plugin_factory.py
@@ -707,11 +707,11 @@ class PluginFactory:
                     >= chunk_size
                 ):
 
+                    self._build_metadata(plugin)
+
                     if current_interface.chunk_stage == ChunkStage.none:
                         self._init_func(plugin)
                         current_interface.chunk_stage = ChunkStage.first
-
-                    self._build_metadata(plugin)
 
                     func(plugin)
 
@@ -724,10 +724,10 @@ class PluginFactory:
             def chunk_ii_close(current_interface: object):
                 plugin = current_interface.parent
 
+                self._build_metadata(plugin)
+
                 if current_interface.chunk_stage == ChunkStage.none:
                     self._init_func(plugin)
-
-                self._build_metadata(plugin)
 
                 if not plugin.update_only_mode:
 

--- a/snakeplane/plugin_factory.py
+++ b/snakeplane/plugin_factory.py
@@ -729,11 +729,13 @@ class PluginFactory:
 
                 self._build_metadata(plugin)
 
-                current_interface.chunk_stage = ChunkStage.last
+                if not plugin.update_only_mode:
 
-                func(plugin)
+                    current_interface.chunk_stage = ChunkStage.last
 
-                plugin.clear_accumulated_records()
+                    func(plugin)
+
+                    plugin.clear_accumulated_records()
 
             @_run_only_if_pi_initialized
             def stream_ii_push_record(

--- a/snakeplane/plugin_factory.py
+++ b/snakeplane/plugin_factory.py
@@ -642,13 +642,13 @@ class PluginFactory:
             input_anchor = input_mgr.get_anchor("AnchorNameFromConfigXmlFile")
             input_df = input_anchor.get_data()
 
-            if(input_anchor[0].chunk_stage == ChunkStage["first"]):
+            if(input_anchor[0].chunk_stage == ChunkStage.first):
                 message = f"First chunk contains records |{input_df.iloc[0]}| to |{input_df.iloc[49]}|"
                 logger.display_info_msg(message)
-            if(input_anchor[0].chunk_stage == ChunkStage["middle"]):
+            if(input_anchor[0].chunk_stage == ChunkStage.middle):
                 message = f"This middle chunk contains records |{input_df.iloc[0]}| to |{input_df.iloc[49]}|"
                 logger.display_info_msg(message)
-            if(input_anchor[0].chunk_stage == ChunkStage["last"]):
+            if(input_anchor[0].chunk_stage == ChunkStage.last):
                 message = f"Last chunk contains records |{input_df.iloc[0]}| to |{input_df.iloc[49]}|"
                 logger.display_info_msg(message)
 
@@ -707,16 +707,16 @@ class PluginFactory:
                     >= chunk_size
                 ):
 
-                    if current_interface.chunk_stage == ChunkStage["none"]:
+                    if current_interface.chunk_stage == ChunkStage.none:
                         self._init_func(plugin)
-                        current_interface.chunk_stage = ChunkStage["first"]
+                        current_interface.chunk_stage = ChunkStage.first
 
                     self._build_metadata(plugin)
 
                     func(plugin)
 
                     # set after func called so first run maintains original chunk_stage
-                    current_interface.chunk_stage = ChunkStage["middle"]
+                    current_interface.chunk_stage = ChunkStage.middle
 
                     plugin.clear_accumulated_records()
 
@@ -724,12 +724,12 @@ class PluginFactory:
             def chunk_ii_close(current_interface: object):
                 plugin = current_interface.parent
 
-                if current_interface.chunk_stage == ChunkStage["none"]:
+                if current_interface.chunk_stage == ChunkStage.none:
                     self._init_func(plugin)
 
                 self._build_metadata(plugin)
 
-                current_interface.chunk_stage = ChunkStage["last"]
+                current_interface.chunk_stage = ChunkStage.last
 
                 func(plugin)
 


### PR DESCRIPTION
Adds 'chunk' mode to `process_data`.

Chunk mode will cause the tool to pull a group (chunk) of records in at a time, and make this chunk of records available to the User Defined Function in the respective input_anchor object.

In addition, a chunk stage (ChunkStage) will be added to the interface object which will resolve to one of the chunk stage values defined in AyxPluginInterface. This allows the User Defined Function to behave differently based on the chunking stage.

It should be noted that when the chunk_size is greater than the size of the data coming in, chunk mode will only run the final chunk stage (currently called "last").