### PR TITLE
Add linux-docker tag to gitlab ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,6 @@
 build:
+  tags:
+    - linux-docker
   image: python:3.6-alpine
   script:
     - apk add gcc musl-dev python3-dev libffi-dev openssl-dev


### PR DESCRIPTION
With new requirements from devops, tags are now required
for each job in gitlab CI/CD pipelines