### PR TITLE
Xmltodict upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 numpy==1.19.1
-xmltodict==0.11.0
+xmltodict==0.12.0

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,6 @@ setup(
     description="The Alteryx Python SDK Abstraction Layer",
     author="Alteryx",
     author_email="awalden@alteryx.com",
-    install_requires=["numpy==1.19.1", "xmltodict==0.11.0"],
+    install_requires=["numpy==1.19.1", "xmltodict==0.12.0"],
     packages=find_packages(),
 )

--- a/snakeplane/version.py
+++ b/snakeplane/version.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-alpha23"
+__version__ = "1.0.0-alpha24"


### PR DESCRIPTION
matching xmltodict version requirements with `ayx-python-sdk`